### PR TITLE
remove need for generator_init()

### DIFF
--- a/examples/fib.c
+++ b/examples/fib.c
@@ -16,8 +16,6 @@ void fib(void *arg)
 
 int main()
 {
-    generator_init();
-
     Generator *g = generator_create(fib);
     foreach (value, g, (void*)(1000*1000)) {
         printf("%ld\n", (long)value);

--- a/examples/square.c
+++ b/examples/square.c
@@ -12,8 +12,6 @@ void square(void *arg)
 
 int main()
 {
-    generator_init();
-
     Generator *g = generator_create(square);
     for (long x = 0; x < 100; ++x) {
         long xx = (long)generator_next(g, (void*)x);


### PR DESCRIPTION
This is done by adding making a Generator_Frame for the generator_stack which holds the rsp to restore to instead of requiring a dummy generator at the bottom.

The only reason the initial bottom level Generator existed was to hold that rsp, let's make it explicitly stored.

Technically you could reuse the Generator's rsp field for this, but then I'd have to worry about reentrancy too much.